### PR TITLE
Handle failure to get device descriptions.

### DIFF
--- a/upnpy/utils.py
+++ b/upnpy/utils.py
@@ -12,8 +12,9 @@ def parse_device_type(device_type):
         :return: Parsed device type
         :rtype: str
     """
-
-    return device_type.split(':')[3:][0]
+    if device_type:
+        return device_type.split(':')[3:][0]
+    return None
 
 
 def parse_service_id(service_id):


### PR DESCRIPTION
This PR uses a similar approach to b11cc65 when a failure is encountered trying to obtain a device description.

Since we also derive the device type from this description, we also need to handle this scenario in `get_device_type`.

There are possibly edge cases to consider that I've missed, but this at least means that device discovery doesn't die straight away on my network. Apparently my QNAP NAS is getting two device entries: the "correct" one on port `1900` and an additional one on port `43668` and it's the latter that is refusing a connection and causing the exception described in #2.

Fixes #2.