### PR TITLE
Fix XML parsing of SOAP responses, added default port behavior for SSDP

### DIFF
--- a/upnpy/ssdp/SSDPDevice.py
+++ b/upnpy/ssdp/SSDPDevice.py
@@ -142,11 +142,15 @@ class SSDPDevice:
         root = minidom.parseString(self.description)
 
         try:
+            header_url = urlparse(location_header_value)
             parsed_url = urlparse(root.getElementsByTagName('URLBase')[0].firstChild.nodeValue)
-            base_url = f'{parsed_url.scheme}://{parsed_url.netloc}'
+
+            if parsed_url.port is not None:
+                base_url = f'{parsed_url.scheme}://{parsed_url.netloc}'
+            else:
+                base_url = f'{parsed_url.scheme}://{parsed_url.netloc}:{header_url.port}'
         except (IndexError, AttributeError):
-            parsed_url = urlparse(location_header_value)
-            base_url = f'{parsed_url.scheme}://{parsed_url.netloc}'
+            base_url = f'{header_url.scheme}://{header_url.netloc}'
 
         self.base_url = base_url
         return base_url


### PR DESCRIPTION
This pull request fundamentally consists of two changes:

1. **Fix XML parsing of UPnP SOAP responses**
Some UPnP devices format their responses putting every tag (and sometimes tag attributes) on a new line. This throws off minidom, which starts to see a bunch of text nodes that only contain a single newline. Sometimes it happens this newline-only text node is the first child of `<s:Body>` and the script parses it believing it to be the argument list of the response, incorrectly returning an empty dictionary even though the device provided output. The fix is in two parts: I added two substitutions with regular expressions that delete all text that only contains white space between a closing tag and a subsequent opening tag and replace newlines within a tag definition with spaces (in case the device puts attributes on new lines too). Then I addressed the issue at the root by selecting the child of `<s:Body>` that has tag name equal to `[ActionName]Response` as per [UPnP specification](http://upnp.org/specs/arch/UPnP-arch-DeviceArchitecture-v1.1.pdf) instead of the first child in case a quirky device does some other funky thing with XML formatting that does not get caught by the substitution. Furthermore, i changed the `getElementByTagName` to `getElementByTagNameNS` and provided a wildcard namespace since, always per UPnP specification, it is not guaranteed that the prefix for `Body` is going to be `s` and the client must accept all valid namespace prefixes.

2. **Add default port to SSDP devices**
I noticed that some devices (in my case, a Samsung Xpress C480W laser printer) do not report a port in the `BaseURL` field and except all further communications to proceed on the same port on which the device XML is provided (it makes sense as the service that provides the device XML descriptor is likely the same service that provides all the other XML descriptors). I added a condition that checks if the parsed `BaseURL` contains a port and, if not, uses the port specified in the `Location` HTML header of the reply. It works for this setup but unfortunately I had no other devices that exhibit this behavior to test this on.

This PR could possibly fix #6 as this is also the behavior I observed prior to applying the first part of the patch. Hope this can help!