### PR TITLE
Handle bad HTTP responses

### DIFF
--- a/upnpy/ssdp/SSDPDevice.py
+++ b/upnpy/ssdp/SSDPDevice.py
@@ -170,6 +170,13 @@ class SSDPDevice:
                 control_url = service.getElementsByTagName('controlURL')[0].firstChild.nodeValue
                 event_sub_url = service.getElementsByTagName('eventSubURL')[0].firstChild.nodeValue
 
+                if scpd_url.startswith(base_url):
+                    scpd_url = scpd_url[len(base_url):]
+                if control_url.startswith(base_url):
+                    control_url = control_url[len(base_url):]
+                if event_sub_url.startswith(base_url):
+                    event_sub_url = event_sub_url[len(base_url):]
+
                 parsed_service_id = utils.parse_service_id(service_id)
 
                 if parsed_service_id not in device_services.keys():

--- a/upnpy/ssdp/SSDPRequest.py
+++ b/upnpy/ssdp/SSDPRequest.py
@@ -95,10 +95,16 @@ class SSDPRequest(SSDPHeader):
 
                 # UDP packet data limit is 65507 imposed by IPv4
                 # https://en.wikipedia.org/wiki/User_Datagram_Protocol#Packet_structure
-
                 response, addr = self.socket.recvfrom(65507)
-                device = SSDPDevice(addr, response.decode())
-                devices.append(device)
+                try:
+                    # Some devices may reply with a malformed error response so
+                    # just ignore them; we don't want one bad device to prevent
+                    # us from creating others.
+                    device = SSDPDevice(addr, response.decode())
+                    devices.append(device)
+                except Exception:
+                    pass
+
         except socket.timeout:
             pass
 


### PR DESCRIPTION
One of the devices on my network yields a malformed HTTP error response. This commit works around that badness.

srp